### PR TITLE
dom.cfg: Add bunch of guest domain configs

### DIFF
--- a/dom.cfg/domu-nfs-nocoproc.cfg
+++ b/dom.cfg/domu-nfs-nocoproc.cfg
@@ -1,0 +1,59 @@
+# =====================================================================
+# Example PV Linux guest configuration
+# =====================================================================
+#
+# This is a fairly minimal example of what is required for a
+# Paravirtualised Linux guest. For a more complete guide see xl.cfg(5)
+
+seclabel='system_u:system_r:domU_t'
+#device_tree = "/boot/dtbs/4.9.0-dom0+/renesas/r8a7796-m3ulcb-domu.dtb"
+#coproc=[ "/soc/gpu1@0xdf000000", "/soc/dsp1@0xdf001000", "/soc/dsp2@0xdf002000", "/soc/gsx@fd000000" ]
+#coproc=[ "/soc/gsx@fd000000" ]
+#irqs=[63, 64, 65, 96, 97, 151]
+
+# Guest name
+name = "DomU"
+
+# 128-bit UUID for the domain as a hexadecimal number.
+# Use "uuidgen" to generate one if required.
+# The default behavior is to generate a new UUID each time the guest is started.
+#uuid = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+# Kernel image to boot
+#kernel = "/var/lib/xen/images/ubuntu-netboot/16.10/linux"
+#ramdisk = "/var/lib/xen/images/ubuntu-netboot/16.10/initrd.gz"
+#kernel = "/boot/vmlinuz-4.10.0-rc6+"
+kernel = "/boot/vmlinuz-4.9.0-domu+"
+
+#bootloader = "/home/root/pygrub"
+#bootloader_arg = ['root=/dev/xvda2']
+
+# Ramdisk (optional)
+ramdisk = "/boot/initrd/initrd.img"
+
+# Kernel command line options
+extra = "root=/dev/nfs nfsroot=192.168.1.1:/tftpboot/domu-rootfs ip=dhcp rw rootwait rootfstype=ext4 console=hvc0 cma=64M"
+
+# Initial memory allocation (MB)
+memory = 256
+
+# Maximum memory (MB)
+# If this is greater than `memory' then the slack will start ballooned
+# (this assumes guest kernel support for ballooning)
+#maxmem = 512
+
+# Number of VCPUS
+vcpus = 4
+
+# Network devices
+# A list of 'vifspec' entries as described in
+# docs/misc/xl-network-configuration.markdown
+vif = [ 'bridge=xenbr0,mac=08:00:27:ff:cb:cd' ]
+
+# Disk Devices
+# A list of `diskspec' entries as described in
+# docs/misc/xl-disk-configuration.txt
+#disk = [ '/dev/vg/guest-volume,raw,xvda,rw' ]
+#disk = [ '/dev/mmcblk1p2,raw,xvda,rw' ]
+
+on_crash = 'preserve'

--- a/dom.cfg/domu-nfs-pass.cfg
+++ b/dom.cfg/domu-nfs-pass.cfg
@@ -1,0 +1,60 @@
+# =====================================================================
+# Example PV Linux guest configuration
+# =====================================================================
+#
+# This is a fairly minimal example of what is required for a
+# Paravirtualised Linux guest. For a more complete guide see xl.cfg(5)
+
+seclabel='system_u:system_r:domU_t'
+device_tree = "/boot/dtbs/4.9.0-dom0+/renesas/r8a7796-m3ulcb-domu.dtb"
+#coproc=[ "/soc/gpu1@0xdf000000", "/soc/dsp1@0xdf001000", "/soc/dsp2@0xdf002000", "/soc/gsx@fd000000" ]
+dtdev=[ "/soc/gsx@fd000000", "/soc/gsx1@fd000000" ]
+irqs=[ 151 ]
+iomem=[ "0xfd000,40" ]
+
+# Guest name
+name = "DomU"
+
+# 128-bit UUID for the domain as a hexadecimal number.
+# Use "uuidgen" to generate one if required.
+# The default behavior is to generate a new UUID each time the guest is started.
+#uuid = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+# Kernel image to boot
+#kernel = "/var/lib/xen/images/ubuntu-netboot/16.10/linux"
+#ramdisk = "/var/lib/xen/images/ubuntu-netboot/16.10/initrd.gz"
+#kernel = "/boot/vmlinuz-4.10.0-rc6+"
+kernel = "/boot/vmlinuz-4.9.0-domu+"
+
+#bootloader = "/home/root/pygrub"
+#bootloader_arg = ['root=/dev/xvda2']
+
+# Ramdisk (optional)
+ramdisk = "/boot/initrd/initrd.img"
+
+# Kernel command line options
+extra = "root=/dev/nfs nfsroot=192.168.1.1:/tftpboot/domu-rootfs ip=192.168.1.101 rw rootwait rootfstype=ext4 console=hvc0 cma=64M"
+
+# Initial memory allocation (MB)
+memory = 256
+
+# Maximum memory (MB)
+# If this is greater than `memory' then the slack will start ballooned
+# (this assumes guest kernel support for ballooning)
+#maxmem = 512
+
+# Number of VCPUS
+vcpus = 4
+
+# Network devices
+# A list of 'vifspec' entries as described in
+# docs/misc/xl-network-configuration.markdown
+vif = [ 'bridge=xenbr0,mac=08:00:27:ff:cb:cd' ]
+
+# Disk Devices
+# A list of `diskspec' entries as described in
+# docs/misc/xl-disk-configuration.txt
+#disk = [ '/dev/vg/guest-volume,raw,xvda,rw' ]
+#disk = [ '/dev/mmcblk1p2,raw,xvda,rw' ]
+
+on_crash = 'preserve'

--- a/dom.cfg/domu-sd-pass.cfg
+++ b/dom.cfg/domu-sd-pass.cfg
@@ -1,0 +1,62 @@
+# =====================================================================
+# Example PV Linux guest configuration
+# =====================================================================
+#
+# This is a fairly minimal example of what is required for a
+# Paravirtualised Linux guest. For a more complete guide see xl.cfg(5)
+
+disk = [ 'phy:/dev/mmcblk1p2,xvda' ]
+
+seclabel='system_u:system_r:domU_t'
+device_tree = "/boot/dtbs/4.9.0-dom0+/renesas/r8a7796-m3ulcb-domu.dtb"
+#coproc=[ "/soc/gpu1@0xdf000000", "/soc/dsp1@0xdf001000", "/soc/dsp2@0xdf002000", "/soc/gsx@fd000000" ]
+dtdev=[ "/soc/gsx@fd000000", "/soc/gsx1@fd000000" ]
+irqs=[ 151 ]
+iomem=[ "0xfd000,40" ]
+
+# Guest name
+name = "DomU"
+
+# 128-bit UUID for the domain as a hexadecimal number.
+# Use "uuidgen" to generate one if required.
+# The default behavior is to generate a new UUID each time the guest is started.
+#uuid = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+# Kernel image to boot
+#kernel = "/var/lib/xen/images/ubuntu-netboot/16.10/linux"
+#ramdisk = "/var/lib/xen/images/ubuntu-netboot/16.10/initrd.gz"
+#kernel = "/boot/vmlinuz-4.10.0-rc6+"
+kernel = "/boot/vmlinuz-4.9.0-domu+"
+
+#bootloader = "/home/root/pygrub"
+#bootloader_arg = ['root=/dev/xvda2']
+
+# Ramdisk (optional)
+# ramdisk = "/boot/initrd/initrd.img"
+
+# Kernel command line options
+extra = "root=/dev/xvda rw rootwait rootfstype=ext4 console=hvc0 cma=64M"
+
+# Initial memory allocation (MB)
+memory = 256
+
+# Maximum memory (MB)
+# If this is greater than `memory' then the slack will start ballooned
+# (this assumes guest kernel support for ballooning)
+#maxmem = 512
+
+# Number of VCPUS
+vcpus = 4
+
+# Network devices
+# A list of 'vifspec' entries as described in
+# docs/misc/xl-network-configuration.markdown
+# vif = [ 'bridge=xenbr0,mac=08:00:27:ff:cb:cd' ]
+
+# Disk Devices
+# A list of `diskspec' entries as described in
+# docs/misc/xl-disk-configuration.txt
+#disk = [ '/dev/vg/guest-volume,raw,xvda,rw' ]
+#disk = [ '/dev/mmcblk1p2,raw,xvda,rw' ]
+
+on_crash = 'preserve'


### PR DESCRIPTION
domu-nfs-pass.cfg     - domU FS on NFS, SGX passthrough, no coproc
domu-sd-pass.cfg      - domU FS on BLK, SGX passthrough, no coproc
domu-nfs-nocoproc.cfg - domU FS on NFS, no passthrough, no coproc

Signed-off-by: Oleksandr Tyshchenko <olekstysh@gmail.com>