### PR TITLE
xen_install: add new xen_install_boot command

### DIFF
--- a/xen_helpers.conf.defaults
+++ b/xen_helpers.conf.defaults
@@ -16,8 +16,6 @@
 # the actual number.
 #export XEN_BUILD_JOBS=MAX
 
-# TFTP sever dir
-# export XEN_DIR_TFTPBOOT=/srv/tftp
 
 # Paths used by cda, updated by cda_save
 
@@ -29,4 +27,4 @@
 # export XEN_DIR_PVR_KM=/home/a2k/projects/andr2000/pvr_km
 # export XEN_DIR_PVR_META=/home/a2k/projects/sysroots/rcar/meta/metag/2.8
 # export XEN_DIR_PVR_UM=/home/a2k/projects/andr2000/pvr_um
-
+# export XEN_DIR_TFTP=/srv/tftp

--- a/xen_helpers.conf.defaults
+++ b/xen_helpers.conf.defaults
@@ -16,6 +16,9 @@
 # the actual number.
 #export XEN_BUILD_JOBS=MAX
 
+# TFTP sever dir
+# export XEN_DIR_TFTPBOOT=/srv/tftp
+
 # Paths used by cda, updated by cda_save
 
 # export XEN_DIR=/home/a2k/projects/andr2000/xen-troops-xen

--- a/xen_helpers.sh
+++ b/xen_helpers.sh
@@ -537,6 +537,11 @@ xen_install()
 	sudo -E bash -c "cp -rfv dist/* ${XEN_DIR_ROOTFS_DOM0}"
 }
 
+xen_install_boot()
+{
+	cp -vf dist/boot/* ${XEN_DIR_TFTPBOOT}
+}
+
 xen_man()
 {
 	case "$1" in
@@ -554,6 +559,9 @@ xen_man()
 			;;
 		xen_install)
 			echo "xen_install -- install Xen"
+			;;
+		xen_install_boot)
+			echo "xen_install_boot -- install boot images to TFTP dir"
 			;;
 		xen_kernel_config)
 			echo "xen_kernel_config -- run environment for kernel config"

--- a/xen_helpers.sh
+++ b/xen_helpers.sh
@@ -227,7 +227,7 @@ _xen_cd_completion()
 
 _xen_cda_completion()
 {
-	_xen_cd_completion "xen dom0 domu domd rootfs0 rootfsu pvr_km pvr_um pvr_meta" ""
+	_xen_cd_completion "xen dom0 domu domd rootfs0 rootfsu pvr_km pvr_um pvr_meta tftp" ""
 }
 
 _xen_pvr_completion()
@@ -262,6 +262,9 @@ cd() {
 		;;
 		"${XEN_DIR_PVR_META}")
 			export XEN_SETUP_ID_EXT="pvr_meta"
+		;;
+		"${XEN_DIR_TFTP}")
+			export XEN_SETUP_ID_EXT="tftp"
 		;;
 	esac
 	_xen_bash_prompt
@@ -301,6 +304,9 @@ cda()
 		;;
 		pvr_meta)
 			cd "${XEN_DIR_PVR_META}"
+		;;
+		tftp)
+			cd "${XEN_DIR_TFTP}"
 		;;
 		*)
 		;;
@@ -349,6 +355,10 @@ cda_save()
 		pvr_meta)
 			_xen_set_config XEN_DIR_PVR_META ${PWD}
 			export XEN_DIR_PVR_META=${PWD}
+		;;
+		tftp)
+			_xen_set_config XEN_DIR_TFTP ${PWD}
+			export XEN_DIR_TFTP=${PWD}
 		;;
 		*)
 		;;
@@ -539,7 +549,7 @@ xen_install()
 
 xen_install_boot()
 {
-	cp -vf dist/boot/* ${XEN_DIR_TFTPBOOT}
+	cp -vf dist/boot/* ${XEN_DIR_TFTP}
 }
 
 xen_man()
@@ -594,6 +604,7 @@ xen_man()
 			echo "    domu    -- DomU kernel"
 			echo "    rootfs0 -- Dom0 root filesystem"
 			echo "    pvr_km  -- PVR KM"
+			echo "    tftp    -- TFTP server root"
 			;;
 		cda_save)
 			echo "cda_save -- save work directories paths for use with cda"


### PR DESCRIPTION
This command installs xen uimage and xenpolicy into TFTP server directory.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>